### PR TITLE
Make it work with any iterable table

### DIFF
--- a/src/TableView.jl
+++ b/src/TableView.jl
@@ -112,4 +112,6 @@ function showtable(t::Union{DNDSparse, NDSparse}; rows=1:100, colopts=Dict(), kw
     w()
 end
 
+showtable(t; kwargs...) = showtable(table(t); kwargs...)
+
 end # module


### PR DESCRIPTION
I think that should be enough to make it work directly with all sources that support the [IterableTables.jl](https://github.com/davidanthoff/IterableTables.jl) interface. But, someone better try it, because this is done blind, i.e. I didn't have the time right now to figure out the whole WebIO.jl setup issue.

Maybe @piever could try this branch quickly? I think you have everything working?