### PR TITLE
Various fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 julia:
   - 1.0
   - 1.1
+  - 1.2
   - nightly
 matrix:
   allow_failures:

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,20 @@
+name = "TableView"
+uuid = "40c74d1a-b44c-5b06-a7c1-6cbea58ea978"
+
+[deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+JSExpr = "97c1335a-c9c5-57fe-bc5d-ec35cebe8660"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Observables = "510215fc-4207-5dde-b226-833fc4488ee2"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+WebIO = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29"
+
+[compat]
+julia = "≥ 0.7.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,0 @@
-julia 0.7
-WebIO
-JSExpr
-Tables
-JSON
-Observables

--- a/src/TableView.jl
+++ b/src/TableView.jl
@@ -28,6 +28,10 @@ struct IteratorAndFirst{F, T}
         first = iterate(x)
         return new{typeof(first), typeof(x)}(first, x, len)
     end
+    function IteratorAndFirst(first, x)
+        len = Base.haslength(x) ? length(x) + 1 : 1
+        return new{typeof(first), typeof(x)}(first, x, len)
+    end
 end
 Base.IteratorSize(::Type{IteratorAndFirst{F, T}}) where {F, T} = Base.IteratorSize(T)
 Base.length(x::IteratorAndFirst) = x.len
@@ -38,6 +42,8 @@ function Base.iterate(x::IteratorAndFirst, st)
     st === nothing && return nothing
     return iterate(x.source, st)
 end
+
+showtable(table::AbstractMatrix; kwargs...) = showtable(Tables.table(table); kwargs...)
 
 function showtable(table; dark = false, height = :auto, width = "100%")
     rows = Tables.rows(table)

--- a/src/TableView.jl
+++ b/src/TableView.jl
@@ -171,6 +171,10 @@ function table2json(rows, names, types; requested = nothing)
                 print(io, ':')
                 if col isa Number
                     JSON.print(io, col)
+                elseif col === nothing
+                    JSON.print(io, "nothing")
+                elseif col === missing
+                    JSON.print(io, "missing")
                 else
                     JSON.print(io, sprint(print, col))
                 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,3 +19,7 @@ end
     ]
     @test showtable(nttable) isa WebIO.Scope
 end
+@testset "normal array" begin
+    array = rand(10, 10)
+    @test showtable(array) isa WebIO.Scope
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,21 @@
 using TableView
 using Test, WebIO
 
-version = readchomp(joinpath(@__DIR__, "..", "ag-grid.version"))
-
-@test isfile(joinpath(@__DIR__, "..", "deps", "ag-grid-$(version)", "ag-grid.js"))
-
-nttable = [
-    (a = 2.0, b = 3),
-    (a = 3.0, b = 12)
-]
-@test showtable(nttable) isa WebIO.Scope
+@testset "installation" begin
+    version = readchomp(joinpath(@__DIR__, "..", "ag-grid.version"))
+    @test isfile(joinpath(@__DIR__, "..", "deps", "ag-grid-$(version)", "ag-grid.js"))
+end
+@testset "named tuple table" begin
+    nttable = [
+        (a = 2.0, b = 3),
+        (a = 3.0, b = 12)
+    ]
+    @test showtable(nttable) isa WebIO.Scope
+end
+@testset "named tuple table with missing and nothing" begin
+    nttable = [
+        (a = 2.0, b = 3, c = missing),
+        (a = 3.0, b = 12, c = nothing)
+    ]
+    @test showtable(nttable) isa WebIO.Scope
+end


### PR DESCRIPTION
This fixes https://github.com/JuliaComputing/TableView.jl/issues/19 and makes `showtable` work for everything that's `Tables.table`able (which includes Arrays, for example).

I'm not sure if this representation is what we want. Compare `DataFrame`s default printing:
```
3×1 DataFrame
│ Row │ a       │
│     │ Union…⍰ │
├─────┼─────────┤
│ 1   │ 1       │
│ 2   │ missing │
│ 3   │         │
```
to 
![image](https://user-images.githubusercontent.com/6735977/58867839-73b8ad80-86bb-11e9-8893-fd92f8a52cf0.png)
I was playing around with `nothing` => `-` or `n/a` and `missing` => `?` but it's not clear to me if those are actually any better.