### PR TITLE
#64 fix display precision of big numbers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TableView"
 uuid = "40c74d1a-b44c-5b06-a7c1-6cbea58ea978"
-version = "0.6.4"
+version = "0.6.5"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/TableView.jl
+++ b/src/TableView.jl
@@ -264,7 +264,7 @@ function table2json(schema, rows, types; requested = nothing)
         columnwriter = JSON.Writer.CompactContext(io)
         JSON.begin_object(columnwriter)
         Tables.eachcolumn(schema, row) do val, ind, name
-            if val isa Real && isfinite(val) && -js_max_safe_int < val < js_max_safe_int
+            if val isa Real && isfinite(val) && -js_max_safe_int < trunc(Int128, val) < js_max_safe_int
                 JSON.show_pair(columnwriter, ser, name, val)
             elseif val === nothing || val === missing
                 JSON.show_pair(columnwriter, ser, name, repr(val))

--- a/src/TableView.jl
+++ b/src/TableView.jl
@@ -266,6 +266,8 @@ function table2json(schema, rows, types; requested = nothing)
         Tables.eachcolumn(schema, row) do val, ind, name
             if val isa Number && isfinite(val) && -js_max_safe_int < val < js_max_safe_int
                 JSON.show_pair(columnwriter, ser, name, val)
+            elseif val == nothing || val == missing
+                JSON.show_pair(columnwriter, ser, name, repr(val))
             else
                 JSON.show_pair(columnwriter, ser, name, sprint(print, val))
             end

--- a/src/TableView.jl
+++ b/src/TableView.jl
@@ -266,7 +266,7 @@ function table2json(schema, rows, types; requested = nothing)
         Tables.eachcolumn(schema, row) do val, ind, name
             if val isa Number && isfinite(val) && -js_max_safe_int < val < js_max_safe_int
                 JSON.show_pair(columnwriter, ser, name, val)
-            elseif val == nothing || val == missing
+            elseif val === nothing || val === missing
                 JSON.show_pair(columnwriter, ser, name, repr(val))
             else
                 JSON.show_pair(columnwriter, ser, name, sprint(print, val))

--- a/src/TableView.jl
+++ b/src/TableView.jl
@@ -7,7 +7,7 @@ using Observables: @map
 export showtable
 
 const ag_grid_imports = []
-const js_max_safe_int = 2^53-1
+const js_max_safe_int = Int128(2^53-1)
 
 function __init__()
     version = readchomp(joinpath(@__DIR__, "..", "ag-grid.version"))
@@ -264,7 +264,7 @@ function table2json(schema, rows, types; requested = nothing)
         columnwriter = JSON.Writer.CompactContext(io)
         JSON.begin_object(columnwriter)
         Tables.eachcolumn(schema, row) do val, ind, name
-            if val isa Number && isfinite(val) && -js_max_safe_int < val < js_max_safe_int
+            if val isa Real && isfinite(val) && -js_max_safe_int < val < js_max_safe_int
                 JSON.show_pair(columnwriter, ser, name, val)
             elseif val === nothing || val === missing
                 JSON.show_pair(columnwriter, ser, name, repr(val))

--- a/src/TableView.jl
+++ b/src/TableView.jl
@@ -267,7 +267,7 @@ function table2json(schema, rows, types; requested = nothing)
             if val isa Number && isfinite(val) && -js_max_safe_int < val < js_max_safe_int
                 JSON.show_pair(columnwriter, ser, name, val)
             else
-                JSON.show_pair(columnwriter, ser, name, repr(MIME("text/plain"), val))
+                JSON.show_pair(columnwriter, ser, name, sprint(print, val))
             end
         end
         JSON.end_object(columnwriter)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,16 @@ end
     @test firstrow["d"] == 0
     @test firstrow["e"] == "test_missing"
 end
+@testset "large integers" begin
+    rows = Tables.table([2^52 2^53 2^54])
+    names = [:a, :b, :c]
+    types = [Int64 for _ in 1:3]
+    json = TableView.table2json(Tables.Schema(names, types), rows, types)
+    firstrow = JSON.parse(json)[1]
+    @test firstrow["a"] == 4503599627370496
+    @test firstrow["b"] == "9007199254740992"
+    @test firstrow["c"] == "18014398509481984"
+end
 @testset "normal array" begin
     array = rand(10, 10)
     @test showtable(array) isa WebIO.Scope


### PR DESCRIPTION
Rafactor and simplify the ```table2json``` method as follows:

- Finite numbers larger than 2^53-1 or smaller than -2^53-1 will be treated as a string and enclosed in double-quotes
- Nothing and Missing will use the ```repr``` function to convert to string
- Everything else will use the ```print``` function to convert to string
- Use JSON helper methods to generate the JSON string
- Reduce indentation for improved readability

Closes #64 