### PR TITLE
Added a user call back function to allow settings modifications

### DIFF
--- a/src/TableView.jl
+++ b/src/TableView.jl
@@ -190,6 +190,10 @@ function showtable(table, options::Dict{Symbol, Any} = Dict{Symbol, Any}();
                 )
             )
 
+    # allow a user to modify some of the table settings using a call back function supplied in the options argument            
+    # we need to remove the callback function key from options as it cause the JS serilization process to fail
+    haskey(options, :userCallbackFunc) && ((options[:userCallbackFunc])(options) ; delete!(options, :userCallbackFunc))
+    
     showfun = async ? _showtable_async! : _showtable_sync!
 
     showfun(w, schema, names, types, rows, coldefs, tablelength, id, options)


### PR DESCRIPTION
The user can now supply a callback function that will be called just before rendering the table, allowing changes in the columns definitions (disable sorting, make read-only, remove from display etc.). It the future we can store the “dom” node in options to allow the user to change that too.
This is related to issue #74 