### PR TITLE
add default is_javascript_safe() function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TableView"
 uuid = "40c74d1a-b44c-5b06-a7c1-6cbea58ea978"
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/TableView.jl
+++ b/src/TableView.jl
@@ -274,6 +274,10 @@ function _showtable_async!(w, schema, types, rows, tablelength, id, options, opt
     onimport(w, handler)
 end
 
+function _is_javascript_safe(x)
+    false
+end
+
 function _is_javascript_safe(x::Integer)
     min_safe_int = -(Int64(2)^53-1)
     max_safe_int = Int64(2)^53-1

--- a/src/TableView.jl
+++ b/src/TableView.jl
@@ -274,9 +274,8 @@ function _showtable_async!(w, schema, types, rows, tablelength, id, options, opt
     onimport(w, handler)
 end
 
-function _is_javascript_safe(x)
-    false
-end
+# By default all objects must use repr or sprint
+_is_javascript_safe(x::Real) = false
 
 function _is_javascript_safe(x::Integer)
     min_safe_int = -(Int64(2)^53-1)


### PR DESCRIPTION
This is needed to be able to support any arbitrary object type rather than only Floats and Integers.